### PR TITLE
Fix the previous messages system

### DIFF
--- a/plugins/ai-search-frontend/package.json
+++ b/plugins/ai-search-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-ai-search-frontend",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/ai-search-frontend/src/components/AISearchComponent/AISearchComponent.tsx
+++ b/plugins/ai-search-frontend/src/components/AISearchComponent/AISearchComponent.tsx
@@ -185,7 +185,16 @@ export const AISearchComponent = () => {
     }
   };
 
+  const previousMessages = () => {
+    // We want everything in the conversations array EXCEPT the last message
+    // This is because the last message is the one that the user just sent
+    // and the server gets mad if the previous messages aren't exactly 
+    // alternating between user and bot
+    return conversation.slice(0, conversation.length - 1);
+  }
+
   const sendQueryToServer = async (_agentId: number, userQuery: any) => {
+    console.log(previousMessages())
     try {
       const response = await fetch(
         `${backendUrl}/api/proxy/tangerine/api/agents/${selectedAgent.id}/chat`,
@@ -195,7 +204,7 @@ export const AISearchComponent = () => {
           body: JSON.stringify({
             query: userQuery,
             stream: 'true',
-            prvMsgs: conversation,
+            prevMsgs: previousMessages()
           }),
           cache: 'no-cache',
         },
@@ -305,6 +314,7 @@ export const AISearchComponent = () => {
     const conversationEntry = {
       text: msg,
       sender: USER,
+      done: false
     };
     setConversation([...conversation, conversationEntry]);
   };

--- a/plugins/ai-search-frontend/src/components/AISearchComponent/AISearchComponent.tsx
+++ b/plugins/ai-search-frontend/src/components/AISearchComponent/AISearchComponent.tsx
@@ -194,7 +194,6 @@ export const AISearchComponent = () => {
   }
 
   const sendQueryToServer = async (_agentId: number, userQuery: any) => {
-    console.log(previousMessages())
     try {
       const response = await fetch(
         `${backendUrl}/api/proxy/tangerine/api/agents/${selectedAgent.id}/chat`,
@@ -237,11 +236,9 @@ export const AISearchComponent = () => {
     try {
       while (true) {
         const chunk = await reader.read();
-        console.log(chunk);
         const { done, value } = chunk;
 
         if (done) {
-          console.log('Stream done');
           setLoading(false);
           setResponseIsStreaming(false);
           break;


### PR DESCRIPTION
We had a bug where the previous messages weren't being sent on the correct property. When I changed the previous messages property to be the right one it broke. I was very confused but after looking at the backend logs it bombs out if the previous mesages aren't exactly even with use user-ai-user-ai pairs. So I added a function to remove the most recent message from the conversation before we send it as prevMessages