### PR TITLE
Handle possible malformed citation titles

### DIFF
--- a/plugins/ai-search-frontend/package.json
+++ b/plugins/ai-search-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-ai-search-frontend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/ai-search-frontend/src/components/AISearchComponent/Citation.tsx
+++ b/plugins/ai-search-frontend/src/components/AISearchComponent/Citation.tsx
@@ -15,7 +15,6 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 const parseTitle = citation => {
-  //debugger
   const title = citation.metadata?.title || citation.metadata?.title || citation.metadata?.filename || citation.metadata?.full_path || "Untitled Document";
   // Remove trailing / if present
   if (title.endsWith('\\')) {

--- a/plugins/ai-search-frontend/src/components/AISearchComponent/Citation.tsx
+++ b/plugins/ai-search-frontend/src/components/AISearchComponent/Citation.tsx
@@ -15,9 +15,8 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 const parseTitle = citation => {
-  const title = citation.metadata.title
-    ? citation.metadata.title
-    : citation.metadata.filename;
+  //debugger
+  const title = citation.metadata?.title || citation.metadata?.title || citation.metadata?.filename || citation.metadata?.full_path || "Untitled Document";
   // Remove trailing / if present
   if (title.endsWith('\\')) {
     return title.slice(0, -1);


### PR DESCRIPTION
*Belt and suspenders mate, belt and suspenders.*

If the citation `metadata.title` is missing we fall back to multiple possible values until landing on a default.