### PR TITLE
Citation links open in new tab. Ran formatter

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -48,7 +48,7 @@ proxy:
     '/tangerine':
       target: ${TANGERINE_CLUSTER_URL}
       headers:
-        Authorization: Bearer ${TANGERINE_CLUSTER_API_TOKEN}
+        Authorization: Bearer ${TANGERINE_TOKEN}
       allowedMethods: ['POST', 'GET']
       credentials: dangerously-allow-unauthenticated
 

--- a/plugins/ai-search-frontend/package.json
+++ b/plugins/ai-search-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-ai-search-frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/ai-search-frontend/src/components/AISearchComponent/Citation.tsx
+++ b/plugins/ai-search-frontend/src/components/AISearchComponent/Citation.tsx
@@ -15,7 +15,12 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 const parseTitle = citation => {
-  const title = citation.metadata?.title || citation.metadata?.title || citation.metadata?.filename || citation.metadata?.full_path || "Untitled Document";
+  const title =
+    citation.metadata?.title ||
+    citation.metadata?.title ||
+    citation.metadata?.filename ||
+    citation.metadata?.full_path ||
+    'Untitled Document';
   // Remove trailing / if present
   if (title.endsWith('\\')) {
     return title.slice(0, -1);
@@ -26,7 +31,7 @@ const parseTitle = citation => {
 const CitationContent = ({ citation, expanded }) => {
   const makeLink = metadata => {
     if (metadata?.citation_url) {
-      return metadata.citation_url
+      return metadata.citation_url;
     } else {
       // deprecated method, where full_path was used to construct citation url
       // return the path prepended by /docs/
@@ -40,7 +45,7 @@ const CitationContent = ({ citation, expanded }) => {
   }
   return (
     <Card>
-      <CardTitle >
+      <CardTitle>
         <Button
           variant="link"
           icon={<ExternalLinkSquareAltIcon />}
@@ -54,7 +59,22 @@ const CitationContent = ({ citation, expanded }) => {
       </CardTitle>
       <CardBody>
         <TextContent>
-          <Markdown style={{marginLeft: '1em'}}>{citation.page_content}</Markdown>
+          <Markdown
+            style={{ marginLeft: '1em' }}
+            options={{
+              overrides: {
+                a: {
+                  component: 'a',
+                  props: {
+                    target: '_blank',
+                    title: 'Note: Relative links are broken and will not work.',
+                  },
+                },
+              },
+            }}
+          >
+            {citation.page_content}
+          </Markdown>
         </TextContent>
       </CardBody>
     </Card>


### PR DESCRIPTION
This PR forces links in citations to open in new tabs. I also added a tool tip to the links to explain relative links don't work - a stop gap solution but a quick hit while I was in there. Also ran the formatter.